### PR TITLE
Packaging fix to use tarball URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,10 @@ NestJS ChangeLog is a change tracker for NestJS. It is similar to [PaperTrail](h
 
 ## Getting Started
 
-First, install the package.
+First, install the package using the link to a [release] tarball:
 
 ```bash
-npm install "https://github.com/porterville-citrus-inc/nestjs-changelog" # Latest on main
-
-# ---- OR ----
-
-npm install "https://github.com/porterville-citrus-inc/nestjs-changelog#semver:^1.0.0" # Specific version
+npm install "https://github.com/porterville-citrus-inc/nestjs-changelog/archive/refs/tags/nestjs-changelog-1.0.22.tgz"
 ```
 
 Wrap your typeorm `ConnectionOptions` with our helper function that adds the necessary entity and subscriber.
@@ -62,6 +58,8 @@ import { ChangeModule } from 'nestjs-changelog';
     ]
 })
 ```
+
+[release]: https://github.com/porterville-citrus-inc/nestjs-changelog/releases
 
 ## Tracking Changes
 
@@ -216,4 +214,31 @@ const entity = await connection.manager.findOne(SomeEntity, 1);
 await connection.manager.delete(SomeEntity, { id: 1 });
 // manually create an entry
 await changeRepository.createChangeEntry(entity, ChangeAction.DELETE);
+```
+
+## Creating a new release
+
+This package is intended for use directly from Github, using NPM's ability to
+add a dependency from a given URL. To create a new release for use this way, use
+one of the included NPM scripts.
+
+Note: this requires the `gh` CLI installed and authenticated. You will also need
+to configure the default remote repo: `gh repo set-default`
+
+To release incrementing the version:
+
+```sh
+npm run release --next-ver=minor # Or any string accepted by `npm version`.
+```
+
+Shortcut to release incrementing the patch version:
+
+```sh
+npm run rel:patch
+```
+
+To release without incrementing the version (useful when testing):
+
+```sh
+npm run release
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test": "mocha lib/spec/change.spec.ts",
     "prepack": "npm run build",
     "prerelease": "npm version $npm_config_next_ver && npm pack",
-    "release": "gh release create v$(npm run env | sed -En 's/^npm_package_version=(.+$)/\\1/p') *.tgz"
+    "release": "gh release create v$(npm run env | sed -En 's/^npm_package_version=(.+$)/\\1/p') *.tgz",
+    "rel:patch": "npm run release --next-ver=patch",
+    "postrelease": "rimraf *.tgz"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "index.*"
   ],
   "scripts": {
-    "prepare": "npm run build",
     "prebuild": "rimraf dist",
     "build": "tsc -p tsconfig.build.json",
-    "test": "mocha lib/spec/change.spec.ts"
+    "test": "mocha lib/spec/change.spec.ts",
+    "prepack": "npm run build",
+    "prerelease": "npm version $npm_config_next_ver && npm pack",
+    "release": "echo gh release create $npm_package_version *.tgz"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "mocha lib/spec/change.spec.ts",
     "prepack": "npm run build",
     "prerelease": "npm version $npm_config_next_ver && npm pack",
-    "release": "echo gh release create $npm_package_version *.tgz"
+    "release": "gh release create v$(npm run env | sed -En 's/^npm_package_version=(.+$)/\\1/p') *.tgz"
   },
   "author": "",
   "license": "MIT",

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-npm version patch
-npm publish


### PR DESCRIPTION
## Changes

- Changed `package.json` to replace `prepare` with `release` script
- Updated `README` for the new way to install, and how to create releases
- Removed `publish.sh` - no longer needed

## Purpose

Allows users to install the package from Github, ensuring it is correctly prepared for use.

## Approach

This uses NPM scripts to automate the versioning, building, packaging, and releasing of the package.

## Notes

Encountered [many] similar [issues] about how the prepare script was [not running] for people, but none of the proposed solutions were working.

In the end, after looking at the NPM log, I realized NPM simply does not run the `prepare` script for regular installs.

It looks like they intend the script to be used only when packaging, or when doing local development (though it's still unclear how it determines this), but not for installing for production from a URL, especially if the package requires an intermediate step before use (such as transpiling from TS).

In any case, it is unsuitable for our purposes, which is why this PR changes the method of installing to a tarball URL, which needs manual releases to be done.

[many]: https://github.com/npm/cli/issues/310
[issues]: https://community.atlassian.com/t5/Bitbucket-questions/npm-ci-amp-dependencies-over-SSH-build-missing-or-scripts-not/qaq-p/1315647
[not running]: https://stackoverflow.com/a/56368594/63209
